### PR TITLE
Interventions updates

### DIFF
--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -12,7 +12,7 @@
 from xml.etree.ElementTree import Element
 from xml.etree import ElementTree
 
-from vecnet.openmalaria.scenario.core import Section, attribute, attribute_setter, section, tag_value
+from vecnet.openmalaria.scenario.core import Section, attribute, attribute_setter, section, tag_value, tag_value_setter
 from vecnet.openmalaria.scenario.healthsystem import HealthSystem
 
 
@@ -178,16 +178,28 @@ class AnophelesParams(Section):
     @tag_value
     def deterrency(self):
         return "deterrency", "value", float
+    @deterrency.setter
+    @tag_value_setter(tag="deterrency", attrib="value")
+    def deterrency(self, value):
+        pass
 
     @property
     @tag_value
     def preprandialKillingEffect(self):
         return "preprandialKillingEffect", "value", float
+    @preprandialKillingEffect.setter
+    @tag_value_setter(tag="preprandialKillingEffect", attrib="value")
+    def preprandialKillingEffect(self, value):
+        pass
 
     @property
     @tag_value
     def postprandialKillingEffect(self):
         return "postprandialKillingEffect", "value", float
+    @postprandialKillingEffect.setter
+    @tag_value_setter(tag="postprandialKillingEffect", attrib="value")
+    def postprandialKillingEffect(self, value):
+        pass
 
 
 class ITN(Component):

--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -553,16 +553,28 @@ class Anopheles(Section):
     @tag_value
     def seekingDeathRateIncrease(self):
         return "seekingDeathRateIncrease", "initial", float
+    @seekingDeathRateIncrease.setter
+    @tag_value_setter(tag="seekingDeathRateIncrease", attrib="initial")
+    def seekingDeathRateIncrease(self, value):
+        pass
 
     @property
     @tag_value
     def probDeathOvipositing(self):
         return "probDeathOvipositing", "initial", float
+    @probDeathOvipositing.setter
+    @tag_value_setter(tag="probDeathOvipositing", attrib="initial")
+    def probDeathOvipositing(self, value):
+        pass
 
     @property
     @tag_value
     def emergenceReduction(self):
         return "emergenceReduction", "initial", float
+    @emergenceReduction.setter
+    @tag_value_setter(tag="emergenceReduction", attrib="initial")
+    def emergenceReduction(self, value):
+        pass
 
     @property
     def decays(self):

--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -400,7 +400,7 @@ class HumanInterventions(Section):
     """
     List of human interventions
     """
-    def add(self, intervention):
+    def add(self, intervention, id=None):
         """
         Add an intervention to vectorPop section.
         intervention is either ElementTree or xml snippet
@@ -422,6 +422,11 @@ class HumanInterventions(Section):
             return
 
         assert isinstance(component.name, (str, unicode))
+
+        if id is not None:
+            assert isinstance(id, (str, unicode))
+            et.attrib["id"] = id
+
         index = len(self.et.findall("component"))
         self.et.insert(index, et)
 
@@ -600,7 +605,7 @@ class VectorPop(Section):
     A list of parameterisations of generic vector host-inspecific interventions.
     https://github.com/SwissTPH/openmalaria/wiki/GeneratedSchema32Doc#elt-vectorPop
     """
-    def add(self, intervention):
+    def add(self, intervention, name=None):
         """
         Add an intervention to vectorPop section.
         intervention is either ElementTree or xml snippet
@@ -613,6 +618,11 @@ class VectorPop(Section):
         vector_pop = VectorPopIntervention(et)
 
         assert isinstance(vector_pop.name, (str, unicode))
+
+        if name is not None:
+            assert isinstance(name, (str, unicode))
+            et.attrib["name"] = name
+
         index = len(self.et.findall("intervention"))
         self.et.insert(index, et)
 

--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -450,10 +450,14 @@ class MDA(Component):
 
         for option in self.mda.find("effects").findall("option"):
             option_info = {
+                "name": "",
                 "pSelection": float(option.attrib["pSelection"]),
                 "deploys": [],
                 "clearInfections": []
             }
+
+            if "name" in option.attrib:
+                option_info["name"] = option.attrib["name"]
 
             for deploy_section in option.findall("deploy"):
                 option_info["deploys"].append(Deploy(deploy_section))

--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -596,6 +596,60 @@ class VectorPopIntervention(Section):
     An intervention which may have various effects on the vector populations as a whole
     """
     @property
+    def anopheles_xml_snippet(self):
+        xml = """<anopheles mosquito="gambiae">
+                    <emergenceReduction initial=".8">
+                        <decay L="0.2465753424657534" function="step"/>
+                    </emergenceReduction>
+                 </anopheles>"""
+
+        return xml
+
+    def add_or_update_anopheles(self, params):
+        et = None
+        is_update = False
+        desc = self.et.find("description")
+
+        if desc is not None:
+            for anopheles in desc.findall("anopheles"):
+                if anopheles.attrib["mosquito"] == params["mosquito"]:
+                    et = anopheles
+                    is_update = True
+                    break
+
+        if et is None:
+            et = ElementTree.fromstring(self.anopheles_xml_snippet)
+
+        anopheles = Anopheles(et)
+
+        if not is_update:
+            anopheles.mosquito = str(params["mosquito"])
+
+        if "seekingDeathRateIncrease" in params and params["seekingDeathRateIncrease"] is not None:
+            try:
+                anopheles.seekingDeathRateIncrease = float(params["seekingDeathRateIncrease"])
+            except ValueError:
+                pass
+        if "probDeathOvipositing" in params and params["probDeathOvipositing"] is not None:
+            try:
+                anopheles.probDeathOvipositing = float(params["probDeathOvipositing"])
+            except ValueError:
+                pass
+        if "emergenceReduction" in params and params["emergenceReduction"] is not None:
+            try:
+                anopheles.emergenceReduction = float(params["emergenceReduction"])
+            except ValueError:
+                pass
+
+        if not is_update:
+            if desc is None:
+                new_description_element = ElementTree.Element("description")
+                self.et.insert(0, new_description_element)
+                desc = self.et.find("description")
+
+            desc.append(anopheles.et)
+
+    @property
     @attribute
     def name(self):  # name
         """

--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -268,26 +268,46 @@ class Decay(Section):
     @attribute
     def function(self):
         return "function", str
+    @function.setter
+    @attribute_setter(attrib_type=str)
+    def function(self, value):
+        pass
 
     @property
     @attribute
     def L(self):
         return "L", float
+    @L.setter
+    @attribute_setter(attrib_type=float)
+    def L(self, value):
+        pass
 
     @property
     @attribute
     def k(self):
         return "k", float
+    @k.setter
+    @attribute_setter(attrib_type=float)
+    def k(self, value):
+        pass
 
     @property
     @attribute
     def mu(self):
         return "mu", float
+    @mu.setter
+    @attribute_setter(attrib_type=float)
+    def mu(self, value):
+        pass
 
     @property
     @attribute
     def sigma(self):
         return "sigma", float
+    @sigma.setter
+    @attribute_setter(attrib_type=float)
+    def sigma(self, value):
+        pass
 
 
 class GVI(Component):

--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -329,6 +329,56 @@ class GVI(Component):
         self.id = self.et.attrib["id"]
 
     @property
+    def anopheles_xml_snippet(self):
+        xml = """<anophelesParams mosquito="gambiae" propActive="0">
+                    <deterrency value="0.0" />
+                    <preprandialKillingEffect value="0" />
+                    <postprandialKillingEffect value="0" />
+                  </anophelesParams>"""
+
+        return xml
+
+    def add_or_update_anophelesParams(self, params):
+        et = None
+        is_update = False
+
+        for a_param in self.gvi.findall("anophelesParams"):
+            if a_param.attrib["mosquito"] == params["mosquito"]:
+                et = a_param
+                is_update = True
+                break
+
+        if et is None:
+            et = ElementTree.fromstring(self.anopheles_xml_snippet)
+
+        anopheles = AnophelesParams(et)
+
+        anopheles.mosquito = str(params["mosquito"])
+        if params["propActive"] is not None:
+            try:
+                anopheles.propActive = float(params["propActive"])
+            except ValueError:
+                pass
+        if params["deterrency"] is not None:
+            try:
+                anopheles.deterrency = float(params["deterrency"])
+            except ValueError:
+                pass
+        if params["preprandialKillingEffect"] is not None:
+            try:
+                anopheles.preprandialKillingEffect = float(params["preprandialKillingEffect"])
+            except ValueError:
+                pass
+        if params["postprandialKillingEffect"] is not None:
+            try:
+                anopheles.postprandialKillingEffect = float(params["postprandialKillingEffect"])
+            except ValueError:
+                pass
+
+        if not is_update:
+            self.gvi.append(anopheles.et)
+
+    @property
     def decay(self):
         """
         :rtype: Decay

--- a/vecnet/openmalaria/scenario/interventions.py
+++ b/vecnet/openmalaria/scenario/interventions.py
@@ -606,13 +606,13 @@ class VectorPop(Section):
 
     @property
     def interventions(self):
-        """ List of interventions in /scenario/interventions/vectorPop section """
-        array = []
+        """ Dictionary of interventions in /scenario/interventions/vectorPop section """
+        interventions = {}
         if self.et is None:
-            return array
+            return interventions
         for intervention in self.et.findall("intervention"):
-            array.append(VectorPopIntervention(intervention))
-        return array
+            interventions[intervention.attrib['name']] = VectorPopIntervention(intervention)
+        return interventions
 
     def __len__(self):
         return len(self.interventions)
@@ -627,8 +627,17 @@ class VectorPop(Section):
         """
         if len(self.interventions) == 0:
             return
-        for intervention in self.interventions:
+        for intervention_name, intervention in self.interventions.iteritems():
             yield intervention
 
     def __getitem__(self, item):
+        """
+        :rtype: VectorPopIntervention
+        """
+        return self.interventions[item]
+
+    def __getattr__(self, item):
+        """
+        :rtype: VectorPopIntervention
+        """
         return self.interventions[item]

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -275,6 +275,8 @@ class TestScenario(unittest.TestCase):
 
                 anopheles.mosquito = "test"
                 self.assertEqual(anopheles.mosquito, "test")
+                anopheles.emergenceReduction = 0.3
+                self.assertEqual(anopheles.emergenceReduction, 0.3)
 
         scenario.interventions.vectorPop.add(vector_pop_xml, "test")
         self.assertEqual(len(scenario.interventions.vectorPop), 2)

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -230,7 +230,34 @@ class TestScenario(unittest.TestCase):
         self.assertEqual(ddt.decay.L, 0.5)
         self.assertEqual(ddt.decay.function, "exponential")
 
-        self.assertEqual(len(scenario.interventions.human), 3)
+        mda_xml = """
+                    <component id="Coartem" name="Coartem">
+                        <MDA>
+                            <effects>
+                                <option name="0.5" pSelection="0.5">
+                                    <clearInfections stage="liver" timesteps="1"/>
+                                    <clearInfections stage="blood" timesteps="3"/>
+                                </option>
+                                <option name="0.2" pSelection="0.2">
+                                    <clearInfections stage="liver" timesteps="1"/>
+                                    <clearInfections stage="blood" timesteps="4"/>
+                                </option>
+                                <option name="0.3" pSelection="0.3">
+                                    <clearInfections stage="liver" timesteps="1"/>
+                                    <clearInfections stage="blood" timesteps="5"/>
+                                </option>
+                            </effects>
+                        </MDA>
+                    </component>
+                    """
+
+        scenario.interventions.human.add(mda_xml)
+        self.assertEqual(len(scenario.interventions.human), 4)
+
+        mda = scenario.interventions.human["Coartem"]
+        self.assertEqual(mda.id, "Coartem")
+        self.assertEqual(mda.name, "Coartem")
+        self.assertEqual(len(mda.treatment_options), 3)
 
         # Test deployment section
         self.assertEqual(len(scenario.interventions.human.deployments), 1)

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -258,6 +258,7 @@ class TestScenario(unittest.TestCase):
         self.assertEqual(mda.id, "Coartem")
         self.assertEqual(mda.name, "Coartem")
         self.assertEqual(len(mda.treatment_options), 3)
+        self.assertEqual(mda.treatment_options[0]["name"], "0.5")
 
         # Test deployment section
         self.assertEqual(len(scenario.interventions.human.deployments), 1)

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -176,6 +176,9 @@ class TestScenario(unittest.TestCase):
             self.assertEqual(intervention.anophelesParams[0].preprandialKillingEffect, 0.7)
             self.assertEqual(intervention.anophelesParams[0].postprandialKillingEffect, 0)
 
+            intervention.anophelesParams[0].postprandialKillingEffect = 0.2
+            self.assertEqual(intervention.anophelesParams[0].postprandialKillingEffect, 0.2)
+
             # Overwrite anophelesParams.
             anopheles_xml = """<anophelesParams mosquito="funestus" propActive="0.0">
                                 <deterrency value="0.0" />

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -179,6 +179,21 @@ class TestScenario(unittest.TestCase):
             intervention.anophelesParams[0].postprandialKillingEffect = 0.2
             self.assertEqual(intervention.anophelesParams[0].postprandialKillingEffect, 0.2)
 
+            new_anopheles_params = {
+                "mosquito": "gambiae",
+                "propActive": 0.8,
+                "deterrency": 0.2222,
+                "preprandialKillingEffect": 0.9,
+                "postprandialKillingEffect": 0.1
+            }
+            intervention.add_or_update_anophelesParams(new_anopheles_params)
+
+            self.assertEqual(intervention.anophelesParams[0].mosquito, "gambiae")
+            self.assertEqual(intervention.anophelesParams[0].propActive, 0.8)
+            self.assertEqual(intervention.anophelesParams[0].deterrency, 0.2222)
+            self.assertEqual(intervention.anophelesParams[0].preprandialKillingEffect, 0.9)
+            self.assertEqual(intervention.anophelesParams[0].postprandialKillingEffect, 0.1)
+
             # Overwrite anophelesParams.
             anopheles_xml = """<anophelesParams mosquito="funestus" propActive="0.0">
                                 <deterrency value="0.0" />

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -278,6 +278,15 @@ class TestScenario(unittest.TestCase):
                 anopheles.emergenceReduction = 0.3
                 self.assertEqual(anopheles.emergenceReduction, 0.3)
 
+            new_anopheles = {
+                "mosquito": "test",
+                "emergenceReduction": 0.9
+            }
+            intervention.add_or_update_anopheles(new_anopheles)
+
+            self.assertEqual(intervention.anopheles[0].mosquito, "test")
+            self.assertEqual(intervention.anopheles[0].emergenceReduction, 0.9)
+
         scenario.interventions.vectorPop.add(vector_pop_xml, "test")
         self.assertEqual(len(scenario.interventions.vectorPop), 2)
         self.assertTrue(scenario.interventions.vectorPop["test"] is not None)

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -204,11 +204,18 @@ class TestScenario(unittest.TestCase):
         scenario.interventions.human.add(component_xml)
         self.assertEqual(len(scenario.interventions.human), 2)
 
+        scenario.interventions.human.add(component_xml, "testing")
+        self.assertEqual(len(scenario.interventions.human), 3)
+        self.assertTrue(scenario.interventions.human["testing"] is not None)
+        self.assertEqual(scenario.interventions.human["testing"].id, "testing")
+
         ddt = scenario.interventions.human["DDT"]
         self.assertEqual(ddt.id, "DDT")
         self.assertEqual(ddt.name, "DDT")
         self.assertEqual(ddt.decay.L, 0.5)
         self.assertEqual(ddt.decay.function, "exponential")
+
+        self.assertEqual(len(scenario.interventions.human), 3)
 
         # Test deployment section
         self.assertEqual(len(scenario.interventions.human.deployments), 1)
@@ -253,6 +260,11 @@ class TestScenario(unittest.TestCase):
 
                 anopheles.mosquito = "test"
                 self.assertEqual(anopheles.mosquito, "test")
+
+        scenario.interventions.vectorPop.add(vector_pop_xml, "test")
+        self.assertEqual(len(scenario.interventions.vectorPop), 2)
+        self.assertTrue(scenario.interventions.vectorPop["test"] is not None)
+        self.assertEqual(scenario.interventions.vectorPop["test"].name, "test")
 
         # Scenario without interventions
         scenario1 = Scenario(

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -280,7 +280,7 @@ class TestScenario(unittest.TestCase):
         # No vectorPop section
         scenario = Scenario(
             open(os.path.join(base_dir, os.path.join("input", "scenario70k60c_no_interventions.xml"))).read())
-        self.assertEqual(scenario.interventions.vectorPop.interventions, [])
+        self.assertEqual(scenario.interventions.vectorPop.interventions, {})
         self.assertEqual(len(scenario.interventions.vectorPop), 0)
         i = None
         for i in scenario.interventions.vectorPop:
@@ -290,7 +290,7 @@ class TestScenario(unittest.TestCase):
         # Empty vectorPop section
         scenario = Scenario(
             open(os.path.join(base_dir, os.path.join("files", "test_scenario", "empty_vectorpop_section.xml"))).read())
-        self.assertEqual(scenario.interventions.vectorPop.interventions, [])
+        self.assertEqual(scenario.interventions.vectorPop.interventions, {})
         self.assertEqual(len(scenario.interventions.vectorPop), 0)
         i = None
         for i in scenario.interventions.vectorPop:
@@ -308,19 +308,14 @@ class TestScenario(unittest.TestCase):
         scenario = Scenario(
             open(os.path.join(base_dir, os.path.join("files", "test_scenario", "triple_larvacing.xml"))).read())
         self.assertEqual(len(scenario.interventions.vectorPop), 3)
-        interventions = []
-        for i in scenario.interventions.vectorPop:
-            interventions.append(i.name)
-        self.assertEqual(interventions, ["int1", "int2", "int3"])
-        self.assertEqual(scenario.interventions.vectorPop[0].name, "int1")
-        self.assertEqual(scenario.interventions.vectorPop[1].name, "int2")
-        self.assertEqual(scenario.interventions.vectorPop[2].name, "int3")
-        self.assertRaises(IndexError, lambda: scenario.interventions.vectorPop[3])
-        self.assertRaises(TypeError, lambda: scenario.interventions.vectorPop["string"])
+        self.assertEqual(scenario.interventions.vectorPop["int1"].name, "int1")
+        self.assertEqual(scenario.interventions.vectorPop["int2"].name, "int2")
+        self.assertEqual(scenario.interventions.vectorPop["int3"].name, "int3")
+        self.assertRaises(KeyError, lambda: scenario.interventions.vectorPop["int4"])
 
         # test name setter
-        scenario.interventions.vectorPop[0].name = "new name"
-        self.assertEqual(scenario.interventions.vectorPop[0].name, "new name")
+        scenario.interventions.vectorPop["int1"].name = "new name"
+        self.assertEqual(scenario.interventions.vectorPop["new name"].name, "new name")
 
     def test_vaccine_interventions(self):
         scenario = Scenario(open(os.path.join(base_dir, os.path.join("files", "test_scenario", "vaccine_interventions.xml"))).read())

--- a/vecnet/openmalaria/tests/test_scenario.py
+++ b/vecnet/openmalaria/tests/test_scenario.py
@@ -260,6 +260,28 @@ class TestScenario(unittest.TestCase):
         self.assertEqual(len(mda.treatment_options), 3)
         self.assertEqual(mda.treatment_options[0]["name"], "0.5")
 
+        mda_params = {
+                "name": "0.5",
+                "pSelection": "0.5",
+                "deploys": [{
+                    "maxAge": "10",
+                    "minAge": "0",
+                    "p": "1",
+                    "components": ["Coartem"]
+                }],
+                "clearInfections": [{
+                    "timesteps": "2",
+                    "stage": "liver"
+                }, {
+                    "timesteps": "3",
+                    "stage": "blood"
+                }]
+        }
+        mda.add_or_update_treatment_option(mda_params)
+        self.assertEqual(len(mda.treatment_options), 3)
+        self.assertEqual(mda.treatment_options[0]["name"], "0.5")
+        self.assertEqual(mda.treatment_options[0]["deploys"][0].p, 1)
+
         # Test deployment section
         self.assertEqual(len(scenario.interventions.human.deployments), 1)
         for deployment in scenario.interventions.human.deployments:


### PR DESCRIPTION
This PR adds support for manipulating the entire interventions section.

- Support for adding/updating human and vectorPop interventions.
- Support for each specific intervention sub-type (GVI, MDA, VectorPop, etc.).

Note: Increased support for Vaccine interventions will be in a separate PR and version.